### PR TITLE
fix: names for component includes

### DIFF
--- a/petrware/.vite/deps/_metadata.json
+++ b/petrware/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "226c46ae",
+  "configHash": "bc4af600",
+  "lockfileHash": "a42ca70d",
+  "browserHash": "1c779a87",
+  "optimized": {},
+  "chunks": {}
+}

--- a/petrware/.vite/deps/package.json
+++ b/petrware/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/petrware/src/App.tsx
+++ b/petrware/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import './App.css'
-import Homepage from './components/homepage';
-import EndScreen from './components/endScreen';
+import Homepage from './components/Homepage';
+import EndScreen from './components/EndScreen';
 
 /** The bar at the top that shows the score */
 function ScoreBar(props: {totalScore: number}) {


### PR DESCRIPTION
Component includes previously had incorrect capitalization, causing issues on some environments (like Codespaces)